### PR TITLE
Added macroses support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ Trigger `File Templates: Update Template` and select a template from the list, y
 
 Trigger `File Templates: Delete File` and select a template the list, this template will now be deleted.
 
+## Macroses
+
+You can add on of predefined macroses to your template, like this:
+* `@timestamp@`: Will be replaced with current timestamp in ISO format (i.e. `2016-09-02T08:32:11.073Z`)
+* `@author@`: Will be replaced with your `git config user.name`
+* `@email@`: Will be replaced with your `git config user.email`
+
+To make `@author@` and `@email@` work in your project, it must be a GIT repository.
+
 ## Config
 
 The only config for file templates is the location it saves templates, by default this is `~/.atom/file-templates` but you can set it to anything.

--- a/lib/macros.coffee
+++ b/lib/macros.coffee
@@ -1,0 +1,10 @@
+Macroses =
+  'timestamp': -> (new Date()).toISOString()
+  'author':    -> atom.project.getRepositories()[0].getConfigValue('user.name')
+  'email':     -> atom.project.getRepositories()[0].getConfigValue('user.email')
+
+module.exports.process = (text) ->
+  text.replace /@(\w+)@/g, (_, $1) -> try
+    Macroses[$1]()
+  catch error
+    '@'+$1

--- a/lib/views/new-file-view.coffee
+++ b/lib/views/new-file-view.coffee
@@ -1,4 +1,5 @@
 TemplateListView = require './template-list-view'
+Macros = require '../macros'
 
 fs = require 'fs-plus'
 path = require 'path'
@@ -8,7 +9,7 @@ module.exports =
     confirmed: (item) ->
       @cancel()
       atom.workspace.open().then ->
-        contents = fs.readFileSync path.join(atom.config.get('file-templates.templateStore'), item.hash + '.template'), "utf8"
+        contents = Macros.process fs.readFileSync path.join(atom.config.get('file-templates.templateStore'), item.hash + '.template'), "utf8"
         grammar = atom.grammars.grammarForScopeName(item.grammarScope)
 
         atom.workspace.getActiveTextEditor().setText(contents)


### PR DESCRIPTION
Hello! I'm added support of macroses in templates. Let me explain.
In template you can write something like:

``` javascript
// Author: @author@ <mailto:@email@>
// Timestamp: @timestamp@
```

And after you execute a `File Templates: New File` with that template you get a new file with:

``` javascript
// Author: rand0me <mailto:dandydan2k@gmail.com>
// Timestamp: 2016-09-02T08:41:16.101Z
```

It has zero configuration because it will get `user.name` and `user.email` from `git config` of current repository, so it is simple to use :wink:
